### PR TITLE
Fixed:芸人機能の修正

### DIFF
--- a/app/models/comedian.rb
+++ b/app/models/comedian.rb
@@ -25,6 +25,7 @@ class Comedian < ApplicationRecord
   validates :twitter_url, length: {maximum: 255}
   validates :youtube_url, length: {maximum: 255}
   validates :comment, presence: true
+  validates :genre, presence: true
   validates :twitter_url, format: /\A#{URI::regexp(%w(http https))}\z/, allow_blank: true
   validates :youtube_url, format: /\A#{URI::regexp(%w(http https))}\z/, allow_blank: true
 end

--- a/app/views/comedians/_form.html.erb
+++ b/app/views/comedians/_form.html.erb
@@ -16,8 +16,8 @@
 
 
           <div class="comedian_icon">
-            <%= form.label t('view.comedian.combination_icon') %><br>
-            <%= image_tag(@comedian.combination_icon.url) if @comedian.combination_icon && @comedian.combination_icon.url %>
+            <%= form.label t('view.comedian.combination_icon') %>
+            <%= image_tag(@comedian.combination_icon.thumb.url) if @comedian.combination_icon && @comedian.combination_icon.thumb.url %><br>
             <%= form.file_field :combination_icon %>
             <%= form.hidden_field :combination_icon_cache %>
           </div>

--- a/app/views/comedians/confirm.html.erb
+++ b/app/views/comedians/confirm.html.erb
@@ -41,11 +41,8 @@
           </div>
 
           <%= form.submit t('view.comedian.entry'), class: "btn btn-outline-secondary mt-2" %>
-        <% end %>
+          <%= form.submit t('view.back'), name: 'back', class: "btn btn-outline-secondary mt-2" %>
 
-        <%= form_with(model: @comedian, url: new_comedian_path, local: true, method: "get") do |form| %>
-          <%= form.hidden_field :combination_icon_cache %>
-          <%= form.submit t('view.back'), name: 'back' %>
         <% end %>
       </div>
     </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -17,7 +17,7 @@
           <% end %>
           <div class="field">
             <%= f.label t('view.user.icon') %>
-            <p><%= image_tag @user.icon.to_s %></p>
+            <p><%= image_tag @user.icon.thumb.to_s %></p>
             <%= f.file_field :icon %>
           </div>
 

--- a/db/migrate/20200328102536_change_column_add_notnull_comedians.rb
+++ b/db/migrate/20200328102536_change_column_add_notnull_comedians.rb
@@ -1,0 +1,5 @@
+class ChangeColumnAddNotnullComedians < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :comedians, :genre, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_22_104022) do
+ActiveRecord::Schema.define(version: 2020_03_28_102536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2020_03_22_104022) do
   create_table "comedians", force: :cascade do |t|
     t.string "combination_name", null: false
     t.string "email", null: false
-    t.string "genre"
+    t.string "genre", null: false
     t.string "twitter_url"
     t.string "youtube_url"
     t.text "combination_icon"

--- a/spec/models/comedian_spec.rb
+++ b/spec/models/comedian_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Comedian, type: :model do
     comedian.combination_name = 'comedian001'
     comedian.email = 'comedian001@gmail.com'
     comedian.comment = 'comedian001です。よろしくお願いします。'
+    comedian.genre = '漫才'
     comedian.save
     expect(comedian.combination_name).to eq 'comedian001'
     expect(comedian.email).to eq 'comedian001@gmail.com'
@@ -66,6 +67,18 @@ RSpec.describe Comedian, type: :model do
         expect(comedian).to be_valid
       end
     end
+
+    context 'genre値が' do
+      it '空白の場合、無効である' do
+        comedian.genre = ' '
+        expect(comedian).to_not be_valid
+      end
+      it '入力されている場合、有効である' do
+        comedian.genre = '漫才'
+        expect(comedian).to be_valid
+      end
+    end
+
     context 'twitter_url値が' do
       it '正規表現にマッチしており、255文字以上の場合、無効である' do
         comedian.twitter_url = 'https://www.' + 'a' * 244


### PR DESCRIPTION
- 投稿確認時に戻るボタンを押した場合、入力した内容が保持されているように修正
- 芸人投稿時にジャンルカラムへの入力を必須に変更
- 芸人プロフィールの登録画面、編集画面、確認画面の表示が並ぶように修正